### PR TITLE
Add tests for negative numbers (currently failing)

### DIFF
--- a/R/parse_command.R
+++ b/R/parse_command.R
@@ -151,7 +151,6 @@ parse_command <- function(str) {
   ## First, test for target-like-ness.  That will be things that are
   ## names or character only.  Numbers, etc will drop through here:
   is_target <- unname(vlapply(command[-1], is_target_like))
-
   ## ...and we check them and I() arguments here:
   if (any(!is_target)) {
     i <- c(FALSE, !is_target)

--- a/tests/testthat/test-parse-command.R
+++ b/tests/testthat/test-parse-command.R
@@ -228,8 +228,12 @@ test_that("Literal arguments", {
               is_identical_to(TRUE))
   expect_that(parse_command("foo(target_arg, 1L)")$args[[2]],
               is_identical_to(1L))
+  expect_that(parse_command("foo(target_arg, -1L)")$args[[2]],
+              is_identical_to(-1L))
   expect_that(parse_command("foo(target_arg, 1.0)")$args[[2]],
               is_identical_to(1.0))
+  expect_that(parse_command("foo(target_arg, -1.0)")$args[[2]],
+              is_identical_to(-1.0))
   expect_that(parse_command("foo(target_arg, 1i)")$args[[2]],
               is_identical_to(1i))
 })


### PR DESCRIPTION
Hi Rich,

I found out that in a remake.yml one cannot currently pass in negative numbers without using the I function, i.e. "sin(I(-1))", whereas positive number can be passed in directly "sin(1)". 

Problem is in this [`parse_command` function](https://github.com/richfitz/remake/blob/20176867803bf26b357f5ec6bf0ff7259f629e5a/R/parse_command.R#L146), and then in [`check_literal_arg` function](https://github.com/richfitz/remake/blob/20176867803bf26b357f5ec6bf0ff7259f629e5a/R/parse_command.R#L158)

E.g compare two example below:

```
> remake:::parse_command("foo(target_arg, -1L)")
Error in FUN(X[[1L]], ...) : Unknown special function -
> remake:::parse_command("foo(target_arg, 1L)")
$rule
[1] "foo"
...
```
