### PR TITLE
added tutorial information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ remake::make_script()
 * A large [data synthesis project](https://github.com/dfalster/baad) (unfortunately complicated by being a templated remakefile).
 * The accounts for a [coffee coop](https://github.com/aammd/CoffeeCoop)
 
+## Tutorials
+
+Some tutorials on using remake with different datasets. 
+
+* [Tutorial on remake from Ecostats workshop](https://github.com/nicercode/2015.12.08-EcoStats)
+* [Tutorial on remake using the Gapminder data](https://github.com/ropenscilabs/remake-tutorial)
+
+
+
 # Installation
 
 Install using [devtools](https://github.com/hadley/devtools):


### PR DESCRIPTION
At the rOpenSci unconference and for an Ecostats course, there were some tutorials on remake made. Suggested adding a section to the README that includes links to these tutorials.