### PR TITLE
makes console output abbreviation optional

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -182,7 +182,7 @@ diagram <- function(..., remake_file="remake.yml") {
 remake_verbose <- function(verbose=getOption("remake.verbose", TRUE),
                           noop=getOption("remake.verbose.noop", TRUE),
                           command=getOption("remake.verbose.command", TRUE),
-                          command_abbreviate=TRUE,
+                          command_abbreviate=getOption("remake.verbose.command.abbreviate", TRUE),
                           target=NULL) {
   if (inherits(verbose, "remake_verbose")) {
     verbose


### PR DESCRIPTION
Useful when running remake in the background and redirecting console to a log file.

In addition, the current implementation of abbreviation causes the output to be completely blank when filenames are longer than allowed width. This could be fixed separately, but in the meanwhile, turning off abbreviation is a savior.