### PR TITLE
Remove codetools dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,6 @@ License: BSD_2_clause + file LICENSE
 LazyData: true
 Imports:
     R6 (>= 2.0.0),
-    codetools,
     crayon,
     digest,
     optparse,

--- a/R/code_dependencies.R
+++ b/R/code_dependencies.R
@@ -36,8 +36,7 @@ code_dependencies <- function(f, hide_error=TRUE) {
         }
       }
     } else { # keep going
-      walk(e[[1L]]) # not sure if this is needed...
-      for (a in as.list(e[-1L])) {
+      for (a in as.list(e)) {
         if (!missing(a)) {
           walk(a)
         }

--- a/R/code_dependencies.R
+++ b/R/code_dependencies.R
@@ -1,65 +1,56 @@
-## TODO: According to JJ, there is support for doing this sort of
-## thing in a DTL package - possibly called 'codedeps'.  Probably
-## worth finding out how that works and seeing if I can make this
-## faster and more reliable.
-code_dependencies <- function(f, hide_errors=TRUE) {
+code_dependencies <- function(f, hide_error=TRUE) {
   env <- environment(f)
-  ## Exclude these:
+  ## Exclude these as they shadow variables:
   args <- names(formals(f))
 
-  leaf <- function(e, w) {
-    if (!is.symbol(e)) { # A literal of some type
-      return()
-    }
-    e_name <- deparse(e)
-
-    ## Shadowed by argument:
-    ## TODO: Nested function definitions will not work correctly
-    ## here; we'd need to switch the "active" function.  Getting this
-    ## wrong is most likely to cause false positives.
-    if (e_name %in% args) {
-      return()
-    }
-
-    ## TODO: Things like get() will totally confuse this.
-    if (!exists(e_name, env, inherits=FALSE) &&
-        ((!exists(e_name, env)       || # local variable, probably
-          is_active_binding(e_name)))) {  # using remake active bindings
-      return()
-    }
-    r <- try(eval(e, env), silent=hide_errors)
-    if (!is.null(r) && is.function(r) && !is.primitive(r)) {
-      if (identical(environment(r), env)) {
-        if (!identical(r, f)) {
-          ## TODO: Why not e_name here?
-          ret$functions <<- c(ret$functions, as.character(e))
-        }
-      } else {
-        r_env <- environment(r)
-        if (is.environment(r_env)) {
-          ret$packages <<- c(ret$packages, packageName(r_env))
-        }
-      }
-    }
-  }
-  call <- function (e, w) {
-    codetools::walkCode(e[[1]], w)
-    for (a in as.list(e[-1])) {
-      if (!missing(a)) {
-        codetools::walkCode(a, w)
-      }
-    }
-  }
+  ## This is what we build up:
   ret <- list(functions=character(0),
               packages=character(0))
-  walker <- codetools::makeCodeWalker(call=call, leaf=leaf, write=cat)
-  codetools::walkCode(body(f), walker)
+
+  walk <- function(e) {
+    if (!is.recursive(e)) { # leaf
+      if (!is.symbol(e)) { # A literal of some type
+        return()
+      }
+      e_name <- deparse(e)
+      ## Shadowed by argument:
+      if (e_name %in% args) {
+        return()
+      }
+      ## Can't find this function in scope; possibly global...
+      if (!exists(e_name, env)) {
+        return()
+      }
+      r <- get(e_name, env)
+      if (is.function(r) && !is.primitive(r)) {
+        if (identical(environment(r), env)) {
+          if (!identical(r, f)) {
+            ret$functions <<- c(ret$functions, e_name)
+          }
+        } else {
+          ## TODO: for issue #85 descend into some packages here.
+          r_env <- environment(r)
+          if (is.environment(r_env)) {
+            ret$packages <<- c(ret$packages, packageName(r_env))
+          }
+        }
+      }
+    } else { # keep going
+      walk(e[[1L]]) # not sure if this is needed...
+      for (a in as.list(e[-1L])) {
+        if (!missing(a)) {
+          walk(a)
+        }
+      }
+    }
+  }
+
+  walk(body(f))
   lapply(ret, unique)
 }
 
-## TODO: this looks overly complicated?
 functions_in_environment <- function(env) {
-  pos <- ls(env)
+  pos <- ls(env, all.names=TRUE)
   keep_if_fn <- function(x) {
     if (is.function(x)) x else NULL
   }
@@ -68,8 +59,6 @@ functions_in_environment <- function(env) {
   obj[!vlapply(obj, is.null)]
 }
 
-## TODO: This can be replaced with the free function $info(rule) I
-## believe.
 code_deps <- function(env) {
   fns <- functions_in_environment(env)
   deps <- lapply(fns, code_dependencies)
@@ -82,6 +71,11 @@ code_deps <- function(env) {
     } else {
       fns <- character(0)
     }
+    ## NOTE: This is largely future (and past) proofing in case I
+    ## depend on package information or something else in the future
+    ## (and to keep current caches current).  See
+    ## compare_dependency_status for the only place where the list
+    ## matters here.
     list(functions=function_hashes[fns])
   }
 }

--- a/tests/testthat/code.R
+++ b/tests/testthat/code.R
@@ -29,3 +29,7 @@ myplot <- function(dat) {
 clean_hook <- function() {
   message("running post-cleanup hook")
 }
+
+generate_function <- function() {
+  function(a, b = "wow") NULL
+}

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -186,7 +186,7 @@ test_that("make_environment", {
   cleanup()
   e <- make_environment()
   expect_equal(ls(e),
-               c("clean_hook", "do_plot", "download_data",
+               c("clean_hook", "do_plot", "download_data", "generate_function",
                  "myplot", "process_data"))
   ## TODO: Throw a better error:
   expect_error(make_environment("processed"),

--- a/tests/testthat/test-script.R
+++ b/tests/testthat/test-script.R
@@ -12,7 +12,7 @@ test_that("Build works", {
 
   ## Sourcing the script will run run various "source" commands which
   ## will modify the global environment.  That's not really ideal.
-  extras <- c("do_plot", "clean_hook", "download_data", "myplot",
+  extras <- c("do_plot", "clean_hook", "download_data", "generate_function", "myplot",
               "process_data")
   rm_all_remake_objects <- function() {
     suppressWarnings(rm(list=c("processed", extras), envir=.GlobalEnv))


### PR DESCRIPTION
The walking code is actually pretty simple and things like odin do this
without needing codetools (which may be designed for complicated use
cases but as it's not really documented it's hard to tell).  This will
be easier to extend, especially for things like #85 and possibly #86.

The one remaining commit from the `refactor` branch~~, but currently breaks `create_bindings()`~~.