### PR TITLE
Ignore RStudio-specific files

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,5 @@ tests/testthat/.remake
 ^docker$
 ^TODO\.md$
 ^remake_.*\.tar\.gz$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ doc/
 docker/
 TODO.md
 Rplots.pdf
+.Rproj.user


### PR DESCRIPTION
These files are updated permanently, I don't know how to turn that off. Shall we let RStudio have its way?