### PR TITLE
Do less for multiple targets

### DIFF
--- a/R/remake.R
+++ b/R/remake.R
@@ -314,15 +314,16 @@ remake_make <- function(obj, target_names=NULL, ...) {
   target_names <- remake_default_target(obj, target_names)
   for (t in target_names) {
     remake_print_message(obj, "MAKE", t, style="angle")
-    last <- remake_make1(obj, t, ...)
   }
+  last <- remake_make1(obj, target_names, ...)
   invisible(last)
 }
 
 remake_make1 <- function(obj, target_name, check=NULL) {
+  last_target_name <- utils::tail(target_name, 1L)
   plan <- remake_plan(obj, target_name)
   for (i in plan) {
-    is_last <- i == target_name
+    is_last <- i == last_target_name
     last <- remake_update(obj, i, check=check, return_target=is_last)
   }
   invisible(last)

--- a/tests/testthat/test-api-main.R
+++ b/tests/testthat/test-api-main.R
@@ -55,11 +55,10 @@ test_that("Multiple targets", {
     "[  LOAD ]",
     "[  READ ]", # sources
     "<  MAKE > processed",
+    "<  MAKE > data.csv",
     "[ BUILD ] data.csv",
     "[  READ ]", # packages
-    "[ BUILD ] processed",
-    "<  MAKE > data.csv",
-    "[    OK ] data.csv")
+    "[ BUILD ] processed")
   expect_equal(length(dat$messages), length(expected))
   expect_equal(substr(dat$messages, 1, nchar(expected)), expected)
 })

--- a/tests/testthat/test-remake.R
+++ b/tests/testthat/test-remake.R
@@ -223,3 +223,21 @@ test_that("custom extensions", {
   expect_true(file.exists("data.phy"))
   expect_true(file.exists("plot.pdf"))
 })
+
+test_that("Return values for multiple targets", {
+  cleanup()
+  ret_data <- make("data.csv")
+  ret_processed <- make("processed")
+
+  cleanup()
+  ret <- make(c("processed", "data.csv"))
+  expect_equal(ret, ret_data)
+  ret <- make(c("processed", "data.csv"))
+  expect_equal(ret, ret_data)
+
+  cleanup()
+  ret <- make(c("data.csv", "processed"))
+  expect_equal(ret, ret_processed)
+  ret <- make(c("data.csv", "processed"))
+  expect_equal(ret, ret_processed)
+})


### PR DESCRIPTION
That was *easy* because `remake_make1()` (and its workhorses) are already vectorized for targets. We don't control anymore where the `<MAKE>` progress is printed, but it's still shown at the top for all targets.

Fixes #110.