### PR TITLE
Extract stop_if_duplicated()

### DIFF
--- a/R/remake_internals.R
+++ b/R/remake_internals.R
@@ -45,9 +45,7 @@
     stop("All elements must be targets")
   }
   target_names <- vcapply(targets, "[[", "name")
-  if (any(duplicated(target_names))) {
-    stop("All target names must be unique")
-  }
+  stop_if_duplicated(target_names, "All target names must be unique")
 
   obj_targets <- obj$targets
   target_names_existing <- names(obj_targets)

--- a/R/target.R
+++ b/R/target.R
@@ -48,12 +48,8 @@ target_new_base <- function(name, command, opts, extra=NULL,
 
   ret$depends_name <- with_default(unname(command$depends), character(0))
   ret$arg_is_target <- with_default(command$is_target, logical(0))
-  if (any(duplicated(ret$depends_name))) {
-    stop("Dependency listed more than once")
-  }
-  if (any(duplicated(setdiff(names(command$args), "")))) {
-    stop("All named depends targets must be unique")
-  }
+  stop_if_duplicated(ret$depends_name, "Dependency listed more than once")
+  stop_if_duplicated(setdiff(names(command$args), ""), "All named depends targets must be unique")
 
   ret$cleanup_level <- with_default(opts$cleanup_level, "never")
   ret$cleanup_level <-

--- a/R/utils.R
+++ b/R/utils.R
@@ -432,3 +432,10 @@ mix_cols <- function(cols, col2, p) {
   m3 <- (m * p + m2 * (1-p))/255
   rgb(m3[1, ], m3[2, ], m3[3, ])
 }
+
+stop_if_duplicated <- function(x, message) {
+  if (anyDuplicated(x)) {
+    stop(message, ": ", paste(unique(duplicated(x)), collapse = ", "),
+         call. = FALSE)
+  }
+}

--- a/R/utils_assert.R
+++ b/R/utils_assert.R
@@ -136,8 +136,8 @@ assert_named <- function(x,
     if (length(x) > 0 || !empty_can_be_unnamed) {
       stop(sprintf("%s must be named", name), call.=FALSE)
     }
-  } else if (any(duplicated(nx))) {
-    stop(sprintf("%s must have unique names", name), call.=FALSE)
+  } else {
+    stop_if_duplicated(nx, sprintf("%s must have unique names", name))
   }
 }
 


### PR DESCRIPTION
Uses anyDuplicated() instead of any(duplicated()) for performance, and includes the offending values in the error message. This might need tests, I'm also not sure how to best formulate the error message.