### PR TITLE
Active bindings never make, only fetch

### DIFF
--- a/R/active_bindings.R
+++ b/R/active_bindings.R
@@ -17,22 +17,10 @@ make_active_binding_function <- function(obj, name, type) {
   }
   function(value) {
     if (missing(value)) {
-      ## TODO: Possibly fetch from cache here?  I'm mildly concerned
-      ## about an infinite loop.
       old_wd <- setwd(dir_path)
       on.exit(setwd(old_wd), add = TRUE)
-      obj <- remake(file_name) # TODO: add `verbose=FALSE`
       if (type == "target") {
-        if (isFALSE(obj$config$active)) {
-          ret <- list(name=name)
-          class(ret) <- c("target_placeholder", class(ret))
-          ret
-          ## TODO: We might do something different on "pause" here,
-          ## such as return the last known version of the data.
-        } else {
-          obj$verbose$print_noop <- FALSE
-          uninvisible(remake_make1(obj, name))
-        }
+        fetch(name, remake_file = file_name, verbose = FALSE)
       } else if (type == "source") {
         obj$store$env$env[[name]]
       }

--- a/tests/testthat/test-active-bindings.R
+++ b/tests/testthat/test-active-bindings.R
@@ -74,8 +74,9 @@ test_that("low level", {
               equals(c(rep_len("source", n), "target")))
 
   expect_that(is_active_binding("processed"), is_true())
-  expect_that(d <- processed,
-              shows_message("BUILD"))
+  expect_error(d <- processed, "Object has not been made")
+  make("processed")
+  expect_message(d <- processed, NA)
 
   expect_that(d, is_a("data.frame"))
   expect_message(d <- processed, NA)
@@ -101,8 +102,9 @@ test_that("High level", {
   expect_that(exists("processed"), is_true())
   expect_that(is_active_binding("processed"), is_true())
 
-  expect_that(d <- processed,
-              shows_message("BUILD"))
+  expect_error(d <- processed, "Object has not been made")
+  make("processed")
+  expect_message(d <- processed, NA)
 
   expect_that(d, is_a("data.frame"))
   expect_message(d <- processed, NA)
@@ -125,16 +127,16 @@ test_that("Source changes trigger rebuild on variable access", {
   expect_that(exists("obj", .GlobalEnv), is_true())
   expect_that(is_active_binding("obj"), is_true())
 
-  expect_that(x <- obj, shows_message("\\[.+BUILD.+\\] obj"))
+  expect_error(x <- obj, "Object has not been made")
+  make("obj", remake_file = "remake_active.yml")
   expect_message(x <- obj, NA)
 
   code <- paste0(code, " * 2")
   writeLines(code, filename_code)
-  expect_that(x <- obj, shows_message("loading sources"))
   expect_message(x <- obj, NA)
+  expect_equal(x, 2)
 
-  code <- paste0(code, " * 2")
-  writeLines(code, filename_code)
-  expect_that(x <- obj, shows_message("\\[.+BUILD.+\\] obj"))
+  make("obj", remake_file = "remake_active.yml")
   expect_message(x <- obj, NA)
+  expect_equal(x, 4)
 })


### PR DESCRIPTION
Simple and stupid. Actually, we could have two flavors of bindings, one that calls `make()` and one that calls `fetch()`.

I also wanted to allow adding bindings to `parent.frame()` instead of `.GlobalEnv`. There's the `binding_manager` class that performs the bookkeeping, I wonder if we really need it to be persistent. Could we identify "our" bindings (for later cleanup) by some heuristics? Otherwise we may have to add the binding manager as a hidden variable to the environment or do some other fancy stuff.

Closes #144.