### PR TITLE
Fix printing of progress in the presence of very long target names

### DIFF
--- a/R/remake.R
+++ b/R/remake.R
@@ -217,8 +217,7 @@ remake_print_message <- function(obj, status, target_name,
     str <- sprintf("%s %s", status, target_name)
   } else {
     if (verbose$print_command_abbreviate) {
-      w_extra <- max(0, nchar(target_name) - obj$fmt$target_width)
-      cmd <- abbreviate(cmd, obj$fmt$max_cmd_width - w_extra)
+      cmd <- abbreviate(cmd, obj$fmt$max_cmd_width)
     }
     str <- sprintf(obj$fmt$fmt, status, target_name, paint(cmd, "grey60"))
   }

--- a/R/remake.R
+++ b/R/remake.R
@@ -211,6 +211,8 @@ remake_print_message <- function(obj, status, target_name,
   status <- brackets(paint(sprintf("%5s", status),
                            status_colour(status)), style)
 
+  target_name <- abbreviate(target_name, obj$fmt$target_width)
+
   if (is.null(cmd)) {
     str <- sprintf("%s %s", status, target_name)
   } else {

--- a/R/remake_internals.R
+++ b/R/remake_internals.R
@@ -68,11 +68,14 @@
 .remake_initialize_message_format <- function(obj) {
   width <- getOption("width")
   keep <- !vlapply(obj$targets, function(x) isTRUE(x$implicit))
-  target_width <- max(0, nchar(names(obj$targets)[keep]))
+  min_cmd_width <- 10
+  extra_space <- min(nchar("[ BUILD ] ") + 4 + 1 + min_cmd_width, width)
+  target_width <- min(max(0, nchar(names(obj$targets)[keep])), width - extra_space)
+  max_cmd_width <- max(width - (target_width + extra_space - min_cmd_width), 0)
   list(
     fmt=sprintf("%%s %%-%ds |  %%s", target_width),
     target_width=target_width,
-    max_cmd_width=width - (nchar("[ BUILD ] ") + 1 + target_width + 4))
+    max_cmd_width=max_cmd_width)
 }
 
 ## Used only in `refresh`

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,7 +93,7 @@ abbreviate <- function(str, width, cutoff="...") {
   if (nc <= width) {
     str
   } else if (width < nchar(cutoff)) {
-    character(0)
+    ""
   } else {
     w <- nchar(cutoff)
     paste0(substr(str, 1, width - w), cutoff)


### PR DESCRIPTION
Now abbreviates target names and reserves a minimum width for the command.

CC @wlandau